### PR TITLE
Use plain -g instead of -gstabs

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -78,7 +78,7 @@ CPPFLAGS_gcc =
 CFLAGS_gcc += -Wall -Wextra
 CFLAGS_gcc += -std=gnu99 -pedantic
 CFLAGS_gcc += -Werror
-CFLAGS_gcc += -O -gstabs
+CFLAGS_gcc += -O -g
 CFLAGS_gcc += -Wa,-adhlns=$(@:-o=-lst)
 CFLAGS_gcc += -Werror=format-security
 CFLAGS_gcc += -Wp,-D_FORTIFY_SOURCE=2


### PR DESCRIPTION
The -gstabs switch produces debug output in a non-standard format. This causes problems on architectures like arm64 that doesn't support it, and also makes it difficult for debugging with gdb.