### PR TITLE
fix beep-usage.c generation

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -160,7 +160,7 @@ beep-usage.c: beep-usage.txt
 	echo '#include "beep-usage.h"' >> $@
 	echo 'char beep_usage[] =' >> $@
 	set -e; IFS=""; while read line; do \
-		echo "  \"$${line}\\n\"" >> $@; \
+		echo "  \"$${line}\\\\n\"" >> $@; \
 	done < $<
 	echo '  ;' >> $@
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -160,7 +160,7 @@ beep-usage.c: beep-usage.txt
 	echo '#include "beep-usage.h"' >> $@
 	echo 'char beep_usage[] =' >> $@
 	set -e; IFS=""; while read line; do \
-		echo "  \"$${line}\\\\n\"" >> $@; \
+		printf '  "%s\\n"\n' "$${line}" >> $@; \
 	done < $<
 	echo '  ;' >> $@
 


### PR DESCRIPTION
There is an escaped \ missing in there, which produced an actual newline instead of a literal \n written to the output