### PR TITLE
Make build reproducible

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -263,7 +263,7 @@ CLEANFILES += beep.1
 	mv -f $@.tmp $@
 
 %.1.gz: %.1
-	$(GZIP) --best -c < $< > $@
+	$(GZIP) --best --no-name -c < $< > $@
 
 HTML_DATA += html/README.html
 HTML_DATA += html/INSTALL.html


### PR DESCRIPTION
gzip embeds a timestamp in the compressed data unless the --no-name parameter is used