### PR TITLE
Follow GNU makefile conventions a bit more closely

### DIFF
--- a/.github/workflows/beep-build.yml
+++ b/.github/workflows/beep-build.yml
@@ -15,15 +15,18 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+    - name: create local.mk
+      run: |
+        echo "prefix = ${PWD}/_root" > local.mk
     - name: make
-      run: make prefix="$PWD/_root"
+      run: make
     - name: 'beep --help'
       run: |
         ./beep --help > beep-usage.from--help
         diff -u beep-usage.txt beep-usage.from--help
     - name: 'make check'
-      run: make check prefix="$PWD/_root"
+      run: make check
     - name: 'make install'
-      run: make install prefix="$PWD/_root"
+      run: make install CC=false
     - name: 'list installed files'
-      run: (cd "$PWD/_root" && ls -l $(find . -type f | env LC_ALL=C sort))
+      run: (cd "$PWD/_root" && ls -l $(find . -type f | env LC_ALL=C sort) | nl)

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@
 # Built stuff
 /dox/
 /html/
+/*.html
 /beep-*.tar.gz
 /beep-*.tar.xz
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 # Files that should not be tracked by Git
 
-# The compiled executable
+# The compiled executables
 /beep
 /*.clang
 /*.gcc
+/*.map
 /issue-6-benchmark
 
 # Built sources
@@ -19,6 +20,7 @@
 *.o
 *.i
 *.s
+*.bc
 *.lst
 *.gcc-lst
 /beep.1
@@ -27,6 +29,7 @@
 /beep.1.gz
 
 # Built stuff
+/dox/
 /html/
 /beep-*.tar.gz
 /beep-*.tar.xz
@@ -45,3 +48,7 @@
 *.strace
 /Doxyfile
 /doxygen.stamp
+
+# Test builds
+/_build-*/
+/_prefix-*/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -16,7 +16,7 @@ If you want to run the tests only for the executables compiled with
 clang, run
 
 ```
-[user@host beep]$ make check COMPILERS=clang
+[user@host beep]$ make check TOOLCHAINS=clang
 ```
 
 

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = html/dox
+OUTPUT_DIRECTORY       = dox
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@ This document describes how to install `beep` from sources and how to
 set up the system afterwards.
 
 If you are using `beep` as shipped in a binary distribution package,
-that package should have done most of those steps for you.  The
+that package should have done most of those steps for you.  The one
 notable exception should be the step adding users to the `beep` group.
 
 
@@ -13,7 +13,7 @@ Build requirements
 ==================
 
   * GNU make
-  * clang and/or gcc
+  * clang or gcc
   * Linux kernel headers
 
 
@@ -28,12 +28,25 @@ The easy way is
 ```
 
 By default, `make install` will put the executable `beep` in
-`/usr/bin`.  If you do not like this, change the common GNU Makefile
-standard variables as appropriate, e.g.
+`/usr/local/bin`.  If you do not like this, set override the common
+GNU Makefile convention variables (`prefix`, `bindir`, `docdir`,
+`htmldir`, `mandir`, etc.) as appropriate, e.g.
 
 ```
 [user@host beep]$ make prefix=$HOME/.local
 [user@host beep]$ make prefix=$HOME/.local install
+```
+
+or
+
+```
+[user@host beep]$ cat>local.mk<<EOF
+CC = clang
+prefix = \$(HOME)/.local
+EOF
+[user@host beep]$ make
+[user@host beep]$ make install
+[user@host beep]$ make install-html
 ```
 
 or

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,14 @@ The big and user visible changes.
 1.4.x
 -----
   * Document how to override and disable packaged udev rules.
+  * Changed the build system to be closer to the GNU makefile
+    conventions, i.e. only one compiler/toolchain per build, default
+    installation is prefix=/usr/local instead of prefix=/usr, use GNU
+    style docdir= instead of RPM spec file style pkgdocdir=, etc.
+    Still not using a `configure` script, though, as that is complex.
+    The user writing a `local.mk` with some definitions covers
+    everyone wanting to use the same settings across `make`
+    invocations, though.
 
 1.4.11
 ------

--- a/beep.1.in
+++ b/beep.1.in
@@ -155,7 +155,7 @@ rule to allow write access to
 .B /dev/input/by\-path/platform\-pcspkr\-event\-spkr
 for certain users and/or user groups. For details, see the
 .B beep
-.B @pkgdocdir@/PERMISSIONS.md
+.B @docdir@/PERMISSIONS.md
 file.
 .\"
 .SS "APIs"
@@ -277,8 +277,8 @@ will produce first two 1000Hz beeps, then 5 beeps at the default tone, but only 
 .\"
 .SH SEE ALSO
 .\" Distro packages might want to replace the next line with their README
-.\" .BR @pkgdocdir@/README.Distro ,
-.BR @pkgdocdir@/README.md ,
-.BR @pkgdocdir@/PERMISSIONS.md ,
+.\" .BR @docdir@/README.Distro ,
+.BR @docdir@/README.md ,
+.BR @docdir@/PERMISSIONS.md ,
 .UR "https://github.com/spkr\-beep/beep"
 .UE

--- a/testbuild-all
+++ b/testbuild-all
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+cd "$(dirname "$0")"
+
+export LC_ALL=C
+
+set -ex
+
+make clean
+
+while read id cc cflags
+do
+    abs_top_srcdir="$PWD"
+    builddir="$PWD/_build-$id"
+    prefix="$PWD/_prefix-$id"
+    rm -rf "$builddir" "$prefix"
+    (
+	mkdir "$builddir"
+	cd "$builddir"
+	srcdir="${abs_top_srcdir}"
+
+	run_make() {
+	    make -j -f "$srcdir/GNUmakefile" VPATH="$srcdir" srcdir="$srcdir" CFLAGS="$cflags" CPPFLAGS="-I. -I$srcdir" prefix="$prefix" "$@"
+	}
+
+	run_make CC="$cc"
+	run_make CC="$cc" check
+
+	run_make CC="false" $(sed -n 's|^\(install[^: ]*\):.*|\1|p' "$srcdir/GNUmakefile")
+	(cd "$prefix" && find . -type f | sort) > after-installation.txt
+	nl after-installation.txt
+	if test -s after-installation.txt; then
+	    :
+	else
+	    echo "Error: After installation, there should be files installed."
+	    exit 1
+	fi
+
+	run_make uninstall
+	(cd "$prefix" && find . -type f | sort) > after-uninstall.txt
+	nl after-uninstall.txt
+	if test -s after-uninstall.txt; then
+	    echo "Error: After uninstall, there should be no files left."
+	    exit 1
+	fi
+    )
+done <<EOF
+native-clang	clang	-Dbuilt_with="clang"
+native-gcc	gcc	-Dbuilt_with="gcc"
+EOF
+
+# Note that at this time, the cflags part of the parameter list is
+# only used as a placeholder.

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -32,6 +32,9 @@ FREQS=(440 494 554 587 659 740 831 880 988 1109 1175 1319 1480 1661 1760)
 
 test_dir="$1"
 shift
+BEEP="$1"
+shift
+export BEEP
 
 skip=0
 pass=0
@@ -63,7 +66,7 @@ failure_beeps() {
     if "$have_no_hardware"; then
 	:
     elif test -e "beep"; then
-	./beep -f 880 -l 200  -n -f 659  -n -f 523  -n -f 370 -l 400
+	${BEEP} -f 880 -l 200  -n -f 659  -n -f 523  -n -f 370 -l 400
     fi
 }
 
@@ -72,7 +75,7 @@ success_beeps() {
     if "$have_no_hardware"; then
 	:
     elif test -e "beep"; then
-	./beep -f 220 -l 100 -n -f 275  -l 100 -n -f 330 -l 100  -n -f 440  -l 100 -n -f 550  -l 100 -n -f 660  -l 100 -n -f 880
+	${BEEP} -f 220 -l 100 -n -f 275  -l 100 -n -f 330 -l 100  -n -f 440  -l 100 -n -f 550  -l 100 -n -f 660  -l 100 -n -f 880
     fi
 }
 
@@ -84,15 +87,14 @@ fi
 
 : set -x
 
-for executable; do
-    export BEEP="$PWD/$executable"
+if true; then
     freq_idx=0
-    for test in $(ls -1 tests/*.{bash,sh}); do
+    for test in $(ls -1 "${test_dir}/"*.{bash,sh}); do
 	export FREQ="${FREQS[${freq_idx}]}"
 	base="$(basename $(basename "$test" .bash) .sh)"
 	dir="$(dirname "$test")"
-	actual="${dir}/${executable}--${base}.actual"
-	printf "${hilite}%-13s${normal} ${hilite}%-32s${normal} " "${executable}" "${base}"
+	actual="${dir}/${base}.actual"
+	printf "${hilite}%-32s${normal} " "${base}"
 	if "$have_no_hardware" && grep "^: REQUIRES_HARDWARE" "$test" > /dev/null; then
 	    skip="$(expr "${skip}" + 1)"
 	    echo "$skipmsg"
@@ -144,7 +146,7 @@ for executable; do
 	fi
 	sleep 0.35 || sleep 1
     done
-done
+fi
 
 echo "${pass} passed, ${fail} failed, ${skip} skipped, $(expr "${pass}" + "${fail}" + "${skip}") total."
 


### PR DESCRIPTION
As it turns out, packing two builds using clang and gcc toolchains respectively into a single build process was not the best of ideas: A simple GNUmakefile doing one build is much better in many ways.

Anyways, a simple GNUmakefile is relatively easy to write without the complexities of adding automake and autoconf dependencies. So we try to follow the GNU makefile conventions partly. We do NOT have the mandated configure script, though. Our caller needs to call "make" with the same parameter set (CC=, prefix=, docdir=, etc.) during builds ("make", "make html") as during installs ("make install", "make install-html").